### PR TITLE
slacko 14.0 - _00build.conf with extra commands

### DIFF
--- a/woof-distro/x86/slackware/14.0/_00build.conf
+++ b/woof-distro/x86/slackware/14.0/_00build.conf
@@ -1,0 +1,244 @@
+#
+#  persistent configuration options
+#
+#  see also DISTRO_SPECS DISTRO_PET_REPOS DISTRO_COMPAT_REPOS-*
+#
+#  **NOTE**: check the original file every once in a while
+#            settings might be added or removed...
+#
+
+#----------------
+#support/findpkgs (called by most scripts)
+#----------------
+## set to 'yes' to speed up process..
+USE_FINDPKGS_SEARCH_HELPER=yes
+USE_FINDPKGS_DEP_HELPER=yes
+
+#----------------
+# 2createpackages
+#----------------
+# binaries are usually already stripped. set to 'no' to speed up process
+STRIP_BINARIES=yes
+
+#-------------
+# 3builddistro
+#-------------
+
+## -- Live CD --
+## The default is to use the traditional Puppy Live CD (isolinux)
+## However there are 2 other options.
+## UEFI_ISO overrides GRUB4DOS_ISO if both are set to YES..
+## UEFI_ISO also supports legacy BIOS booting
+##    On 32 bit systems this will still boot legacy BIOS however it
+##      Will not boot 32 bit UEFI machines. These are rare anyway.
+UFEI_ISO=no
+G4DOS_ISO=no
+
+## Kernel tarballs repo URL
+## for choosing/downloading kernel
+KERNEL_REPO_URL=http://distro.ibiblio.org/puppylinux/huge_kernels
+
+## Kernel tarball URL
+## avoid being asked questions about downloading/choosing a kernel
+#KERNEL_TARBALL_URL=http://distro.ibiblio.org/puppylinux/huge_kernels/huge-3.14.55-slacko_noPAE.tar.bz2
+
+## only supported by the GRUB4DOS menu
+## make sure the kernel is compatible with the system you're building
+#ALT_KERNEL_TARBALL=http://smokey01.com/ttuuxxx/WoofCe/kernel-4.1.38-stretch/huge-4.1.38-stretch.tar.bz2
+
+## an array of generically named programs to send to the ADRIVE, FDRIVE, YDRIVE
+## ADRV_INC="abiword gnumeric goffice"
+ADRV_INC=""
+## YDRV_INC=""
+YDRV_INC=""
+## FDRV_INC="" #this one is very experimental and it's recommended to be left unset
+FDRV_INC=""
+
+## Include kernel-kit generated FDRIVE
+## set to yes or no or leave commented to be asked the question at build time
+#KFDRIVE=no
+
+## build devx? yes/no - any other value = ask
+#BUILD_DEVX=yes
+
+## include devx SFS in ISO?
+DEVX_IN_ISO=no
+
+## compression method to be used (SFS files)
+SFSCOMP='-comp xz -Xbcj x86 -b 512K'
+#SFSCOMP='-comp xz'
+#SFSCOMP='-comp gzip'
+#SFSCOMP='-noI -noD -noF -noX'
+
+## if "$WOOF_HOSTARCH" = "$WOOF_TARGETARCH"
+## Would you like to strip all binary executables and shared library files?
+## These are usually already stripped, although some packages may have the shared
+## library files stripped with the '--strip-debug' option only, and extra stripping
+## should be okay. It won't do any harm answering yes here.
+EXTRA_STRIPPING=yes
+
+## -- Dependency check --
+## if $WOOF_HOSTARCH" = "$WOOF_TARGETARCH"
+## The script can optionally do a thorough dependency check
+## This may take a long time.
+CHECK_BINARY_DEPS=no
+
+## PPM2 or the Classic gui for PPM?
+UICHOICE=PPM2
+
+## Puppy is normally run as the 'administrator' (root) user, though there is
+## also 'fido' which is not currently very mature.
+## The structure of Puppy is such that we consider root to be safe (with a full
+## disclaimer of any responsibility if anything does go wrong), but there is a
+## compromise, to run as root but to run Internet apps as user 'spot'.
+## Note, in a running Puppy 'Menu->System->Login & Security Manager'
+##    can be used to enable or disable running as spot.
+RUN_INTERNET_APPS_AS_SPOT=no
+
+## Certain Xorg drivers require KMS (Kernel ModeSetting)
+## A value of '1' means on, '0' means off.
+## assume not using kms at all when boot from sd card (arm arch).
+KMS_i915=1
+KMS_radeon=1
+KMS_nouveau=1
+
+## -- Xorg Auto --
+## - This overrides DISTRO_XORG_AUTO in DISTRO_SPECS..
+## - For ARM it's always set 'no' (may be changed)
+## Do you want Xorg to start automatically at first boot (or at 'pfix=ram'
+## kernel boot param) or run Xorg Wizard? The latter has been the case for
+## earlier puppies. Automatic startup of X usually works, though in some
+## cases may choose the wrong monitor resolution or driver -- which can be"
+## fixed by running Xorg Wizard afterward. (yes/no)
+XORG_AUTO=
+
+## -- Xorg Text DPI (dots por inch) --
+## this is overriden by PTHEME - $DEFAULT_THEME_XORG_TEXT_DPI
+## see 'rootfs-complete/root/.Xresources' for the current value
+## You can specify a font dpi if you wish
+##   ...72 78 84 90 96 102 108 1114 120..
+XORG_TEXT_DPI=
+
+## -- pTheme -- applies only if ptheme pkg is being used
+##    woof-code/rootfs-packages/ptheme/usr/share/ptheme/globals
+## You can choose a ptheme here if you wish
+## otherwise 3builddistro will ask you to choose one
+#PTHEME="Dark Touch"
+#PTHEME="Dark Mouse"
+#PTHEME="Bright Touch"
+#PTHEME="Bright Mouse"
+
+## -- ROX desktop text - black --
+## The ROX-Filer desktop text defaults to white with black shadow, but this is
+## not best for some light backgound images.
+ROX_TEXT_BLACK=no
+
+## ROX-Filer defaults to 'DejaVu Sans 10' font for the desktop. 
+## If you would prefer bold text 'DejaVu Sans Bold 10',
+## type in a full font specification (ex: Mono 12)
+ROXFILER_FONT=
+
+## -- Xload in JWM --
+## By default xload is displayed in JWM. You can disable it here...
+JWM_XLOAD=yes
+
+## -- Custom wallpapers -- if mkwallpaper is in $PATH
+## Do you want to build some custom wallpapers?
+CUSTOM_WALLPAPERS=no
+
+## -- Locale --
+## Puppy is built with a default locale LANG=en_US and keyboard layout KMAP=us,
+## which may be changed after bootup.
+## However, if you are building a language-specific Puppy, you may change the
+## defaults. But, please do make sure that your Puppy has a 'langpack' PET
+## for your language installed -- if one does not exist, then you will have to
+## create one -- see MoManager in the Utility menu, also read the Menu -> Help
+## -> HOWTO Internationalization.
+## see valid locales in /usr/share/i18n/locales
+## (the default is en_US.UTF-8)
+DEFAULTLANG=
+
+## -- Keyboard layout --
+## Default is english (en, us, "")
+## Choose another one if you wish..
+##   azerty be-latin1 br-abnt2 br-abnt br-latin1-abnt2 br-latin1-us by cf
+##   croat cz de de-latin1 dk dvorak dvorak-l dvorak-r es et fi fr
+##   gr hu101 hu il it jp106 lt mk nl no pl pt-latin1 ro ru
+##   se sg sk-qwerty sk-qwertz slovene sv-latin1 uk us wangbe
+KEYMAP=
+
+## -- Default Apps --
+## Not all are implemented in the puppy scripts,
+##   but you can specify a default app if you wish...
+## If you specify a value it will override anything that previously
+##   set that value in the corresponding script...
+## These are the current default*apps (scripts) in /usr/local/bin
+DEFAULTAPPS="
+defaultarchiver=
+defaultaudioeditor=
+defaultaudiomixer=
+defaultaudioplayer=
+defaultbrowser=
+defaultcalendar=
+defaultcdplayer=
+defaultcdrecorder=
+defaultchat=
+defaultchmviewer=
+defaultconnect=
+defaultcontact=
+defaultdraw=
+defaultemail=
+defaultfilemanager=
+defaulthandler=
+defaulthtmleditor=
+defaulthtmlviewer=
+defaultimageeditor=
+defaultimageviewer=
+defaultmediaplayer=
+defaultpaint=
+defaultpdfviewer=
+defaultprocessmanager=
+defaultrun=
+defaultscreenshot=
+defaultspreadsheet=
+defaultterminal=
+defaulttexteditor=
+defaulttextviewer=
+defaultwordprocessor=
+"
+
+## -- NON-FREE firmware --
+## this downloads and installs to fdrive firmwares that
+## may be needed by the kernel drivers (wireless + dvb).
+## a yes or no val to NONFREE_FW is needed to automate build
+## Note 0: FDRV_INC= must be unset
+## Note 1: see the file support/fw.conf for configuration
+## Note 2: if you select b43* (any) in the fw.conf then b43-fwcutter
+## is downloaded, compiled and installed if you don't already have it
+## Note 3: if nouveau=true then a python script 'extract_firmware.py'
+## is downloaded along with the full nvidia driver. It may take a while.
+## Note 4: you can choose to keep downloaded binaries if you set the
+## 'save_dld=true' var in fw.conf. They'll be used next time instead
+## of downloading them again.
+#NONFREE_FW=yes
+
+## -- EXTRA FLAG --
+## This allows some customisation for the iso name
+## eg: slacko64-6.9.9.1-uefi-k3.16.iso
+## where XTRA_FLG='-k3.16' (the dash is a requirement)
+#XTRA_FLG=''
+
+## - extra commands --
+## Here add custom commands to be executed inside sandbox3/rootfs-complete
+EXTRA_COMMANDS="rm usr/bin/memusagestat
+rm usr/bin/rsvg-view-3
+rm usr/bin/x264
+rm -rf usr/lib/xmms
+rm root/.config/rox.sourceforge.net/OpenWith/pMusic
+ln -rs usr/local/bin/7z usr/local/bin/7za
+ln -rs usr/share/applications/gnome-mplayer.desktop root/.config/rox.sourceforge.net/OpenWith/gnome-mplayer
+mkdir root/.config/rox.sourceforge.net/MIME-icons
+cp usr/local/lib/X11/pixmaps/archive48.png root/.config/rox.sourceforge.net/MIME-icons/application_x-7z-compressed.png
+cp ../../packages-slacko/e3_utf8/bin/e3 bin/e3
+"
+


### PR DESCRIPTION
I notice this option when looking at mrfricks xenialpup commits, seems like a great idea, which makes easier to fix some things for specific version. I started with these:

1. Some programs/libraries have dependencies that are not met, sometimes because lib is wrong version, the biggest offender probably being the 1.2MB x264 binary: http://murga-linux.com/puppy/viewtopic.php?p=976194#976194

2. Pmusic is already part of OpenWith from the PMUSIC_TRAY pet, this deletes duplicate entry in OpenWith, and adds one for gnome-mplayer

3. Some programs (xarchive) look for 7za instead of 7z, and will not open 7z archive without finding it. Also added an icon for 7z files so it doesn't look like unknown in Rox

4. the e3 binary can't be stripped or you get "segmentation error", this was fixed then removed from woof-CE so I bring it back for 14.0 specifically

Might add more later or try to add some patches in Devuan next. Tested a build with this _00build.conf and the EXTRA_COMMANDS did work as expected :+1: 